### PR TITLE
fix(deps): lock colors dependency to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 	"dependencies": {
 		"@types/glob": "^7.1.1",
 		"check-links": "^1.1.8",
-		"colors": "^1.4.0",
+		"colors": "1.4.0",
 		"commander": "^5.0.0",
 		"fs-extra": "^9.0.0",
 		"glob": "^7.1.6",


### PR DESCRIPTION
Due to this [commit](https://github.com/Marak/colors.js/commit/074a0f8ed0c31c35d13d28632bd8a049ff136fb6) by the maintainer colors is currently "broken". This commit is in reference to #15